### PR TITLE
feat!: return errors as values where appropriate

### DIFF
--- a/examples/colors.v
+++ b/examples/colors.v
@@ -21,7 +21,7 @@ fn main() {
 	// Colorize all components uniformly
 	b.colorize(Color.magenta)
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		time.sleep(timeout)
 	}
 
@@ -43,7 +43,7 @@ fn main() {
 		indicator: Color.magenta
 	})
 	for _ in 0 .. b2.iters {
-		b2.progress()
+		b2.progress()!
 		time.sleep(timeout * 2)
 	}
 
@@ -65,7 +65,7 @@ fn main() {
 		indicator: Color.magenta
 	})
 	for _ in 0 .. b3.iters {
-		b3.progress()
+		b3.progress()!
 		time.sleep(timeout * 2)
 	}
 
@@ -84,7 +84,7 @@ fn main() {
 	for i in 0 .. b4.iters {
 		j := term.bright_black('(${i + 1}/${b4.width})')
 		b4.post = '${term.cyan('│')} ${j} ${term.blue(b4.spinner())}'
-		b4.progress()
+		b4.progress()!
 		time.sleep(timeout * 3)
 	}
 }

--- a/examples/multi.v
+++ b/examples/multi.v
@@ -8,7 +8,7 @@ import rand
 fn pseudo_dissimilar_progress(mut wg sync.WaitGroup, mut b bartender.Bar) ! {
 	rand_num := rand.intn(100) or { panic(err) }
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		time.sleep((time.millisecond * rand_num) + (50 * time.millisecond))
 	}
 	wg.done()

--- a/examples/simple.v
+++ b/examples/simple.v
@@ -10,7 +10,7 @@ fn main() {
 	// ===========================================================================
 	mut b := bartender.Bar{}
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		time.sleep(timeout)
 	}
 
@@ -25,7 +25,7 @@ fn main() {
 		}
 	}
 	for _ in 0 .. b2.iters {
-		b2.progress()
+		b2.progress()!
 		time.sleep(timeout)
 	}
 
@@ -45,7 +45,7 @@ fn main() {
 		}
 	}
 	for _ in 0 .. b3.iters {
-		b3.progress()
+		b3.progress()!
 		time.sleep(timeout * 5)
 	}
 }

--- a/examples/smooth.v
+++ b/examples/smooth.v
@@ -12,7 +12,7 @@ fn main() {
 	// Add optional fields
 	b.post = ' Push Fill'
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		time.sleep(timeout)
 	}
 
@@ -22,7 +22,7 @@ fn main() {
 		theme: Theme.pull
 	}
 	for _ in 0 .. b2.iters {
-		b2.progress()
+		b2.progress()!
 		time.sleep(timeout)
 	}
 
@@ -33,7 +33,7 @@ fn main() {
 		theme: ThemeVariant{.push, .drain}
 	}
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		time.sleep(timeout)
 	}
 
@@ -43,7 +43,7 @@ fn main() {
 		theme: ThemeVariant{.pull, .drain}
 	}
 	for _ in 0 .. b2.iters {
-		b2.progress()
+		b2.progress()!
 		time.sleep(timeout)
 	}
 	time.sleep(timeout)
@@ -59,7 +59,7 @@ fn main() {
 	}
 	b3.colorize(Color.cyan)
 	for _ in 0 .. b3.iters {
-		b3.progress()
+		b3.progress()!
 		time.sleep(timeout * 2)
 	}
 
@@ -70,7 +70,7 @@ fn main() {
 	}
 	b4.colorize(Color.bright_black)
 	for _ in 0 .. b4.iters {
-		b4.progress()
+		b4.progress()!
 		time.sleep(timeout * 2)
 	}
 
@@ -86,7 +86,7 @@ fn main() {
 	b5.width -= 2
 	b5.colorize(Color.green)
 	for _ in 0 .. b5.iters {
-		b5.progress()
+		b5.progress()!
 		time.sleep(timeout * 10)
 	}
 }

--- a/examples/smooth_multi.v
+++ b/examples/smooth_multi.v
@@ -8,7 +8,7 @@ import rand
 fn pseudo_dissimilar_progress_(mut wg sync.WaitGroup, mut b SmoothBar) ! {
 	rand_num := rand.intn(20) or { panic(err) }
 	for _ in 0 .. b.iters {
-		b.progress()
+		b.progress()!
 		// HACK: modifer to adjust timeout for the scope of this example
 		modifier := if b.pre.str()[..1].int() > 4 { 2 } else { 1 }
 		time.sleep((time.millisecond * rand_num) + (15 * modifier * time.millisecond))

--- a/src/_instructions_multi_bars.v
+++ b/src/_instructions_multi_bars.v
@@ -4,14 +4,11 @@ import term
 import time
 import sync
 
-fn watch_(bars MultiBarType, mut wg sync.WaitGroup) {
+fn watch_(bars MultiBarType, mut wg sync.WaitGroup) ! {
 	// NOTE: Same operation for Bars and SmoothBars (re-check with V's progression if this can be grouped).
 	// Tested match statements and alias types for arrays with bar references.
 	if bars is []&Bar {
-		ensure_mutli(bars) or {
-			eprintln(err)
-			exit(0)
-		}
+		ensure_multi(bars)!
 		for {
 			if bars.draw() {
 				term.show_cursor()
@@ -21,10 +18,7 @@ fn watch_(bars MultiBarType, mut wg sync.WaitGroup) {
 			time.sleep(time.millisecond * 15)
 		}
 	} else if bars is []&SmoothBar {
-		ensure_mutli(bars) or {
-			eprintln(err)
-			exit(0)
-		}
+		ensure_multi(bars)!
 		for {
 			if bars.draw() {
 				term.show_cursor()
@@ -37,7 +31,7 @@ fn watch_(bars MultiBarType, mut wg sync.WaitGroup) {
 	wg.done()
 }
 
-fn ensure_mutli(bars MultiBarType) ! {
+fn ensure_multi(bars MultiBarType) ! {
 	// Same operation for both types.
 	if bars is []&Bar {
 		mut not_multi := []int{}
@@ -47,10 +41,7 @@ fn ensure_mutli(bars MultiBarType) ! {
 			}
 		}
 		if not_multi.len > 0 {
-			return IError(BarError{
-				kind: .missing_multi
-				msg: '${not_multi}'
-			})
+			return bar_error(.missing_multi, not_multi.str())
 		}
 	} else if bars is []&SmoothBar {
 		mut not_multi := []int{}
@@ -60,10 +51,7 @@ fn ensure_mutli(bars MultiBarType) ! {
 			}
 		}
 		if not_multi.len > 0 {
-			return IError(BarError{
-				kind: .missing_multi
-				msg: '${not_multi}'
-			})
+			return bar_error(.missing_multi, not_multi.str())
 		}
 	}
 }

--- a/src/_instructions_reader.v
+++ b/src/_instructions_reader.v
@@ -23,12 +23,12 @@ fn (mut br BarReader) read(mut buf []u8) !int {
 		// SmoothBar won't be visible or will have corrupted chars.
 		Bar {
 			if (f64(br.pos) / br.size * br.bar.width) > br.bar.state.pos {
-				br.bar.progress()
+				br.bar.progress()!
 			}
 		}
 		SmoothBar {
 			if (f64(br.pos) / br.size * br.bar.width) > br.bar.state.pos {
-				br.bar.progress()
+				br.bar.progress()!
 			}
 		}
 	}

--- a/src/_instructions_simple_bar.v
+++ b/src/_instructions_simple_bar.v
@@ -62,21 +62,21 @@ fn (mut b Bar) colorize_components(color BarColor) {
 	}
 }
 
-fn (mut b Bar) progress_() {
+fn (mut b Bar) progress_() ! {
 	if b.state.time.start == 0 {
 		if b.runes_.progress == '' {
 			b.setup()
 		}
 		b.state.time = struct {time.ticks(), 0}
 		term.hide_cursor()
-		os.signal_opt(.int, handle_interrupt) or { panic(err) }
+		os.signal_opt(.int, handle_interrupt)!
 		// Print empty line before first progress to not overwrite current line.
 		if !b.multi {
 			println('')
 		}
 	}
 	if b.state.pos >= b.width_ {
-		panic(IError(BarError{ kind: .finished }))
+		return bar_error(.already_finished, none)
 	}
 
 	b.set_vals()
@@ -98,9 +98,9 @@ fn (mut b Bar) colorize_(color BarColorType) {
 	}
 }
 
-fn (b Bar) eta_(delay u8) string {
+fn (b Bar) eta_(delay u8) !string {
 	if delay > 100 {
-		panic(IError(BarError{ kind: .delay_exceeded }))
+		return bar_error(.delay_exceeded, none)
 	}
 	next_pos := b.state.pos + 1
 	if next_pos < f32(b.width_) * delay / 100 {

--- a/src/_instructions_smooth_bar.v
+++ b/src/_instructions_smooth_bar.v
@@ -190,21 +190,21 @@ fn (b SmoothBar) next_pos() u16 {
 	})
 }
 
-fn (mut b SmoothBar) progress_() {
+fn (mut b SmoothBar) progress_() ! {
 	if b.state.time.start == 0 {
 		if b.runes.s.len == 0 {
 			b.setup()
 		}
 		b.state.time = struct {time.ticks(), 0}
 		term.hide_cursor()
-		os.signal_opt(.int, handle_interrupt) or { panic(err) }
+		os.signal_opt(.int, handle_interrupt)!
 		// Print empty line before first progress to not overwrite current line.
 		if !b.multi {
 			println('')
 		}
 	}
 	if b.state.pos > b.width_ {
-		panic(IError(BarError{ kind: .finished }))
+		return bar_error(.already_finished, none)
 	}
 
 	b.set_vals()
@@ -238,9 +238,9 @@ fn (mut b SmoothBar) colorize_(color Color) {
 	b.runes = painted_runes
 }
 
-fn (b SmoothBar) eta_(delay u8) string {
+fn (b SmoothBar) eta_(delay u8) !string {
 	if delay > 100 {
-		panic(IError(BarError{ kind: .delay_exceeded }))
+		return bar_error(.delay_exceeded, none)
 	}
 	next_pos := b.next_pos()
 	if b.width_ == b.state.pos {

--- a/src/_tests_simple_test.v
+++ b/src/_tests_simple_test.v
@@ -30,16 +30,16 @@ fn test_setup() {
 
 fn test_progress() {
 	mut b := bartender.test_bar
-	b.progress()
+	b.progress()!
 	assert b.format() == '[>                   ] Loading...'
-	b.progress()
+	b.progress()!
 	assert b.format() == '[#>                  ] Loading...'
 	for i := 0; i < 8; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.format() == '[#########>          ] Loading...'
 	for i := 0; i < 10; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.state.pos == 20
 	assert b.format() == '[####################] Done!'
@@ -57,7 +57,7 @@ fn test_eta() {
 	mut b := bartender.test_bar
 	b.setup()
 	for i := 0; i < 10; i++ {
-		b.progress()
+		b.progress()!
 		// would take 2000ms to complete full bar
 		time.sleep(100 * time.millisecond)
 	}
@@ -68,7 +68,7 @@ fn test_eta() {
 	b.width = 40
 	b.reset()
 	for i := 0; i < 20; i++ {
-		b.progress()
+		b.progress()!
 		// would take 2000ms to complete full bar
 		time.sleep(50 * time.millisecond)
 	}

--- a/src/_tests_smooth_test.v
+++ b/src/_tests_smooth_test.v
@@ -20,29 +20,29 @@ fn test_setup() {
 fn test_progress() {
 	mut b := bartender.test_bar
 	// 1/9
-	b.progress()
+	b.progress()!
 	assert b.format() == '▏                                        Loading...'
 	// 2/9
-	b.progress()
+	b.progress()!
 	assert b.format() == '▎                                        Loading...'
 	// 1
 	for i := 0; i < 6; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.format() == '█                                        Loading...'
 	// 1 5/9
 	for i := 0; i < 5; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.format() == '█▌                                       Loading...'
 	// 20 5/9
 	for i := 0; i < bartender.col_iters * 19; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.format() == '████████████████████▌                    Loading...'
 
 	for i := 0; i < bartender.col_iters * 19 + 4; i++ {
-		b.progress()
+		b.progress()!
 	}
 	assert b.format() == '████████████████████████████████████████ Finished!'
 }

--- a/src/errors.v
+++ b/src/errors.v
@@ -3,19 +3,26 @@ module bartender
 struct BarError {
 	Error
 	kind ErrorKind
-	msg  string
+	val  string
 }
 
 enum ErrorKind {
-	finished
+	already_finished
 	delay_exceeded
 	missing_multi
 }
 
 fn (err BarError) msg() string {
 	return match err.kind {
-		.finished { 'Trying to progress already finished bar.' }
+		.already_finished { 'Trying to progress already finished bar.' }
 		.delay_exceeded { 'Delay cannot exceed 100%.' }
-		.missing_multi { 'Failed drawing bars. []&Bar indices not set as multi: ${err.msg}' }
+		.missing_multi { 'Failed drawing bars. []&Bar indices not set as multi: ${err.val}' }
 	}
+}
+
+fn bar_error(kind ErrorKind, val ?string) IError {
+	return IError(BarError{
+		kind: kind
+		val: val or { '' }
+	})
 }

--- a/src/lib.v
+++ b/src/lib.v
@@ -44,8 +44,8 @@ import io
 // == Bar =====================================================================
 
 // Progresses the bar to its next position.
-pub fn (mut b Bar) progress() {
-	b.progress_()
+pub fn (mut b Bar) progress() ! {
+	b.progress_()! // can only fail when calling progress after the bar is finished.
 }
 
 // Colorizes the specified parts of the bar.
@@ -63,7 +63,7 @@ pub fn (b Bar) pct() u16 {
 // The display of the time can be postponed until the progress bar reaches 0-100% completion.
 // A spinner will be shown until the specified delay is reached.
 pub fn (b Bar) eta(delay u8) string {
-	return b.eta_(delay)
+	return b.eta_(delay) or { panic(err) } // can only fail if delay exceeds 100%.
 }
 
 // Returns a snapshot of a spinner based on the bar's current position.
@@ -83,14 +83,14 @@ pub fn (b Bar) reader(reader io.Reader, size u64) &io.BufferedReader {
 
 // Monitors the progress of multiple bars until all of them are finished.
 pub fn (bars []&Bar) watch(mut wg sync.WaitGroup) {
-	watch_(bars, mut wg)
+	watch_(bars, mut wg) or { panic(err) } // can only fail on initial check if bars in bar array not set to `multi: true`.
 }
 
 // == SmoothBar ===============================================================
 
 // Progresses the bar to its next position.
-pub fn (mut b SmoothBar) progress() {
-	b.progress_()
+pub fn (mut b SmoothBar) progress() ! {
+	b.progress_()! // can only fail when calling progress after the bar is finished.
 }
 
 // Colorizes the specified parts of the bar.
@@ -108,7 +108,7 @@ pub fn (b SmoothBar) pct() u16 {
 // The display of the time can be postponed until the progress bar reaches 0-100% completion.
 // A spinner will be shown until the specified delay is reached.
 pub fn (b SmoothBar) eta(delay u8) string {
-	return b.eta_(delay)
+	return b.eta_(delay) or { panic(err) } // can only fail if passed delay exceeds 100%.
 }
 
 // Returns a snapshot of a spinner based on the bar's current position.
@@ -128,7 +128,7 @@ pub fn (b SmoothBar) reader(reader io.Reader, size u64) &io.BufferedReader {
 
 // Monitors the progress of multiple bars until all of them are finished.
 pub fn (bars []&SmoothBar) watch(mut wg sync.WaitGroup) {
-	watch_(bars, mut wg)
+	watch_(bars, mut wg) or { panic(err) } // can only fail on initial check if bars in bar array not set to `multi: true`.
 }
 
 // == Misc ====================================================================


### PR DESCRIPTION
Fixes #6

The change only concerns the `BarType.progress()` methods.

Additionally, comments on errors are updated and internal handling of `IError` returns is abstracted.